### PR TITLE
Fix paddle collision and scoring logic

### DIFF
--- a/pong_game.py
+++ b/pong_game.py
@@ -82,14 +82,42 @@ def init_game(config):
 
     return ball, player_paddle, ai_paddle, screen, clock, game_config
 
+def handle_collisions(ball, player_paddle, ai_paddle, game_config):
+    WIDTH = game_config['width']
+    HEIGHT = game_config['height']
+    BALL_RADIUS = game_config['ball_radius']
+    PADDLE_WIDTH = game_config['paddle_width']
+    player_score_change = 0
+    ai_score_change = 0
+
+    # Player paddle collision
+    if (ball.x - ball.radius <= PADDLE_WIDTH and
+        ball.y >= player_paddle.y and
+        ball.y <= player_paddle.y + player_paddle.height):
+        ball.vx *= -1
+    # AI scores if ball goes past player
+    elif ball.x + ball.radius < 0:
+        ai_score_change = 1
+        ball.reset(WIDTH / 2, HEIGHT / 2)
+
+    # AI paddle collision
+    if (ball.x + ball.radius >= WIDTH - PADDLE_WIDTH and
+        ball.y >= ai_paddle.y and
+        ball.y <= ai_paddle.y + ai_paddle.height):
+        ball.vx *= -1
+    # Player scores if ball goes past AI
+    elif ball.x - ball.radius > WIDTH:
+        player_score_change = 1
+        ball.reset(WIDTH / 2, HEIGHT / 2)
+
+    return player_score_change, ai_score_change
+
 def game_loop(ball, player_paddle, ai_paddle, screen, clock, game_config):
     player_score = 0
     ai_score = 0
 
     WIDTH = game_config['width']
     HEIGHT = game_config['height']
-    BALL_RADIUS = game_config['ball_radius']
-    PADDLE_WIDTH = game_config['paddle_width']
     FPS = game_config['fps']
 
     running = True
@@ -111,21 +139,9 @@ def game_loop(ball, player_paddle, ai_paddle, screen, clock, game_config):
 
         ball.move(HEIGHT)
 
-        if (ball.x <= PADDLE_WIDTH and
-            ball.y >= player_paddle.y and
-            ball.y <= player_paddle.y + player_paddle.height):
-            ball.vx *= -1
-        elif ball.x <= PADDLE_WIDTH:
-            ai_score += 1
-            ball.reset(WIDTH / 2, HEIGHT / 2)
-
-        if (ball.x >= WIDTH - PADDLE_WIDTH - BALL_RADIUS and
-            ball.y >= ai_paddle.y and
-            ball.y <= ai_paddle.y + ai_paddle.height):
-            ball.vx *= -1
-        elif ball.x >= WIDTH - PADDLE_WIDTH - BALL_RADIUS:
-            player_score += 1
-            ball.reset(WIDTH / 2, HEIGHT / 2)
+        player_score_change, ai_score_change = handle_collisions(ball, player_paddle, ai_paddle, game_config)
+        player_score += player_score_change
+        ai_score += ai_score_change
 
         screen.fill(BLACK)
         pygame.draw.rect(screen, WHITE, (ball.x - ball.radius, ball.y - ball.radius, ball.radius * 2, ball.radius * 2))

--- a/test_game_logic.py
+++ b/test_game_logic.py
@@ -1,0 +1,33 @@
+import pong_game
+
+def test_player_paddle_collision():
+    """
+    Tests that the ball correctly collides with the player's paddle.
+    The test simulates a scenario where the ball is at the edge of the paddle,
+    which should trigger a collision.
+    """
+    # 1. Setup game state for the test
+    game_config = {
+        'width': 800,
+        'height': 600,
+        'ball_radius': 10,
+        'paddle_width': 10,
+        'paddle_height': 100
+    }
+
+    # Ball is moving left and is at the edge of the player paddle
+    ball = pong_game.Ball(x=20, y=300, radius=10, speed=5)
+    ball.vx = -5
+
+    player_paddle = pong_game.Paddle(x=0, y=250, width=10, height=100, speed=7)
+    ai_paddle = pong_game.Paddle(x=790, y=250, width=10, height=100, speed=7)
+
+    # 2. Call the collision handler
+    pong_game.handle_collisions(ball, player_paddle, ai_paddle, game_config)
+
+    # 3. Assert that the ball's direction is reversed
+    assert ball.vx > 0, "Ball should have bounced off the player paddle"
+
+if __name__ == '__main__':
+    test_player_paddle_collision()
+    print("Test finished.")


### PR DESCRIPTION
The previous collision detection was inaccurate because it checked for collisions using the ball's center coordinate (`ball.x`) instead of its outer edge. This caused the ball to visibly overlap with the paddle before a collision was registered. The scoring logic was also flawed, awarding points before the ball had fully left the play area.

This commit addresses the issue by:
- Correcting the collision conditions to use the ball's radius for both player and AI paddles.
- Adjusting the scoring logic to award points only when the ball is completely off-screen.
- Refactoring the collision and scoring logic into a separate `handle_collisions` function to improve testability and readability.
- Adding a new test case to `test_game_logic.py` to verify the fix.