### PR TITLE
Fix paddle edge collision detection

### DIFF
--- a/pong_game.py
+++ b/pong_game.py
@@ -92,8 +92,8 @@ def handle_collisions(ball, player_paddle, ai_paddle, game_config):
 
     # Player paddle collision
     if (ball.x - ball.radius <= PADDLE_WIDTH and
-        ball.y >= player_paddle.y and
-        ball.y <= player_paddle.y + player_paddle.height):
+        ball.y + ball.radius >= player_paddle.y and
+        ball.y - ball.radius <= player_paddle.y + player_paddle.height):
         ball.vx *= -1
     # AI scores if ball goes past player
     elif ball.x + ball.radius < 0:
@@ -102,8 +102,8 @@ def handle_collisions(ball, player_paddle, ai_paddle, game_config):
 
     # AI paddle collision
     if (ball.x + ball.radius >= WIDTH - PADDLE_WIDTH and
-        ball.y >= ai_paddle.y and
-        ball.y <= ai_paddle.y + ai_paddle.height):
+        ball.y + ball.radius >= ai_paddle.y and
+        ball.y - ball.radius <= ai_paddle.y + ai_paddle.height):
         ball.vx *= -1
     # Player scores if ball goes past AI
     elif ball.x - ball.radius > WIDTH:

--- a/test_game_logic.py
+++ b/test_game_logic.py
@@ -28,6 +28,30 @@ def test_player_paddle_collision():
     # 3. Assert that the ball's direction is reversed
     assert ball.vx > 0, "Ball should have bounced off the player paddle"
 
+def test_player_paddle_edge_collision():
+    """
+    Tests that the ball correctly collides with the top edge of the player's paddle.
+    This test simulates a scenario where the ball's center is slightly above the paddle,
+    but its radius causes an overlap, which should trigger a collision.
+    """
+    game_config = {
+        'width': 800,
+        'height': 600,
+        'ball_radius': 10,
+        'paddle_width': 10,
+        'paddle_height': 100
+    }
+
+    player_paddle = pong_game.Paddle(x=0, y=250, width=10, height=100, speed=7)
+    ball = pong_game.Ball(x=20, y=245, radius=10, speed=5)
+    ball.vx = -5
+    ai_paddle = pong_game.Paddle(x=790, y=250, width=10, height=100, speed=7)
+
+    pong_game.handle_collisions(ball, player_paddle, ai_paddle, game_config)
+
+    assert ball.vx > 0, "Ball should have bounced off the player paddle's edge"
+
 if __name__ == '__main__':
     test_player_paddle_collision()
-    print("Test finished.")
+    test_player_paddle_edge_collision()
+    print("All tests finished successfully.")


### PR DESCRIPTION
The previous collision detection logic only checked the ball's center against the paddle's height, causing the ball to pass through the paddle's top and bottom edges.

This commit corrects the collision logic in `handle_collisions` to account for the ball's radius, ensuring that collisions are accurately detected across the entire surface of the paddle.

A new test case, `test_player_paddle_edge_collision`, has been added to `test_game_logic.py` to verify the fix. This test specifically checks for collisions at the paddle's edge and now passes with the corrected logic.